### PR TITLE
Python 3 fixes

### DIFF
--- a/glove/__init__.py
+++ b/glove/__init__.py
@@ -1,2 +1,2 @@
-from corpus import Corpus
-from glove import Glove
+from .corpus import Corpus
+from .glove import Glove

--- a/glove/corpus.py
+++ b/glove/corpus.py
@@ -1,9 +1,13 @@
 # Cooccurrence matrix construction tools
 # for fitting the GloVe model.
 
-import cPickle as pickle
+try:
+    # Python 2 compat
+    import cPickle as pickle
+except ImportError:
+    import pickle
 
-from corpus_cython import construct_cooccurrence_matrix
+from .corpus_cython import construct_cooccurrence_matrix
 
 
 class Corpus(object):

--- a/glove/glove.py
+++ b/glove/glove.py
@@ -2,11 +2,16 @@
 # http://nlp.stanford.edu/projects/glove/.
 
 import collections
-import cPickle as pickle
+try:
+    # Python 2 compat
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
 import numpy as np
 import scipy.sparse as sp
 
-from glove_cython import fit_vectors, transform_paragraph
+from .glove_cython import fit_vectors, transform_paragraph
 
 
 class Glove(object):
@@ -69,7 +74,7 @@ class Glove(object):
         for epoch in xrange(epochs):
 
             if verbose:
-                print 'Epoch %s' % epoch
+                print('Epoch %s' % epoch)
 
             # Shuffle the coocurrence matrix
             np.random.shuffle(shuffle_indices)

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,10 @@ if 'darwin' in platform.platform().lower():
 
 
 # Declare extension
-extensions = [Extension("glove_cython", ["glove/glove_cython.pyx"],
+extensions = [Extension("glove.glove_cython", ["glove/glove_cython.pyx"],
                         extra_link_args=["-fopenmp"],
                         extra_compile_args=['-fopenmp']),
-              Extension("corpus_cython", ["glove/corpus_cython.pyx"],
+              Extension("glove.corpus_cython", ["glove/corpus_cython.pyx"],
                         language='C++',
                         extra_compile_args=['-std=c++11', '-O3'])]
 
@@ -31,7 +31,7 @@ setup(
     description=('Python implementation of Global Vectors '
                  'for Word Representation (GloVe)'),
     long_description='',
-    packages=['glove'],
+    packages=["glove"],
     install_requires=['numpy',
                       'cython',
                       'scipy'],


### PR DESCRIPTION
First pass at basic fixes to make the library buildable and importable under Python 3.

The cython extensions are now shipped inside the `glove` top-level package to avoid namespace pollution of the `sys.modules` top level with generic name such as `corpus_cython`.

This should still work under Python 2.
