### PR TITLE
Further optimization of co-occurrence matrix construction

### DIFF
--- a/glove/corpus_cython.pyx
+++ b/glove/corpus_cython.pyx
@@ -162,7 +162,6 @@ def construct_cooccurrence_matrix(corpus, dictionary, int supplied,
     """
 
     # Declare the cooccurrence map
-    cdef map[pair[int, int], double] cooc
     cdef Matrix matrix = Matrix(1000)
 
     # String processing variables.


### PR DESCRIPTION
Use a vector of unordered maps to represent the matrix. Use single 
instead of double precision for this representation to save memory.
This results in lower memory usage and around a 50% speedup.       
