### PR TITLE
Out of core computation

### DIFF
--- a/glove/corpus.py
+++ b/glove/corpus.py
@@ -40,7 +40,7 @@ class Corpus(object):
         if np.min(list(dictionary.values())) != 0:
             raise Exception('Dictionary ids should start at zero')
 
-    def fit(self, corpus, window=10, max_map_size=1000, ignore_missing=False):
+    def fit(self, corpus, window=10, max_map_size=100000, memmap_prefix=None, ignore_missing=False):
         """
         Perform a pass through the corpus to construct
         the cooccurrence matrix. 
@@ -61,13 +61,25 @@ class Corpus(object):
                                ignored.
                                If False, a KeyError is raised.
         """
+
+        if memmap_prefix is not None:
+            row_fname = memmap_prefix + '_rows.mmap'
+            col_fname = memmap_prefix + '_cols.mmap'
+            data_fname = memmap_prefix + '_data.mmap'
+        else:
+            row_fname = None
+            col_fname = None
+            data_fname = None
         
         self.matrix = construct_cooccurrence_matrix(corpus,
                                                     self.dictionary,
                                                     int(self.dictionary_supplied),
                                                     int(window),
                                                     int(ignore_missing),
-                                                    max_map_size)
+                                                    max_map_size,
+                                                    row_fname,
+                                                    col_fname,
+                                                    data_fname)
 
     def save(self, filename):
         

--- a/glove/corpus.py
+++ b/glove/corpus.py
@@ -17,9 +17,13 @@ class Corpus(object):
     Class for constructing a cooccurrence matrix
     from a corpus.
 
-    A dictionary mapping words to ids can optionally
-    be supplied. If left None, it will be constructed
-    from the corpus.
+    Arguments:
+    - dict dictionary: dictionary mapping words to ids can optionally
+                       be supplied. If left None, it will be constructed
+                       from the corpus.
+    - string memmap_prefix: if supplied, the co-occurrence matrix will
+                            be stored on disk in memmapped numpy arrays
+                            whose filenames will start with this prefix.
     """
     
     def __init__(self, dictionary=None, memmap_prefix=None):
@@ -87,11 +91,12 @@ class Corpus(object):
                                       int(ignore_missing),
                                       max_map_size)
 
+        # Don't specify the dtype, as that would cause a copy
+        # of the data array to be created.
         self.matrix = sp.coo_matrix((coo_matrix.data_arr,
                                      (coo_matrix.rows_arr, coo_matrix.cols_arr)),
                                     shape=(len(self.dictionary),
-                                           len(self.dictionary)),
-                                    dtype=np.float32)
+                                           len(self.dictionary)))
 
     def save(self, filename):
         
@@ -126,10 +131,11 @@ class Corpus(object):
             data = np.memmap(instance.data_fname, dtype=np.float32,
                                   mode=mode, offset=np.float32().itemsize)
 
+            # Don't specify the dtype, as that would cause a copy
+            # of the data array to be created.
             instance.matrix = sp.coo_matrix((data,
                                              (rows, cols)),
                                             shape=(len(instance.dictionary),
-                                                   len(instance.dictionary)),
-                                            dtype=np.float32)
+                                                   len(instance.dictionary)))
 
         return instance

--- a/glove/corpus_cython.pyx
+++ b/glove/corpus_cython.pyx
@@ -22,6 +22,90 @@ cdef extern from "math.h":
     double c_abs "fabs"(double)
 
 
+cdef class COOMatrix:
+    """
+    """
+
+    cdef rows_arr
+    cdef cols_arr
+    cdef data_arr
+
+    cdef int memmap
+    cdef row_fname
+    cdef col_fname
+    cdef data_fname
+
+    cdef int[::1] rows
+    cdef int[::1] cols
+    cdef float[::1] data
+
+    def __cinit__(self, row_fname, col_fname, data_fname):
+
+        self.row_fname = row_fname
+        self.col_fname = col_fname
+        self.data_fname = data_fname
+
+        if self.row_fname is not None:
+            self.memmap = 1
+
+        if self.memmap == 1:
+            self.rows_arr = np.memmap(self.row_fname, dtype=np.int32,
+                                      mode='w+', offset=np.int32().itemsize, shape=0)
+            self.cols_arr = np.memmap(self.col_fname, dtype=np.int32,
+                                      mode='w+', offset=np.int32().itemsize, shape=0)
+            self.data_arr = np.memmap(self.data_fname, dtype=np.float32,
+                                      mode='w+', offset=np.float32().itemsize, shape=0)
+        else:
+            self.rows_arr = np.array([], dtype=np.int32)
+            self.cols_arr = np.array([], dtype=np.int32)
+            self.data_arr = np.array([], dtype=np.float32)
+        
+        self.rows = self.rows_arr
+        self.cols = self.cols_arr
+        self.data = self.data_arr
+
+    cdef int size(self):
+
+        return self.rows.shape[0]
+
+    cdef void resize(self, int size):
+
+        mode = 'r+'
+
+        if self.memmap == 1:
+            self.rows_arr = np.memmap(self.row_fname, dtype=np.int32,
+                                      mode=mode, offset=np.int32().itemsize, shape=size)
+            self.cols_arr = np.memmap(self.col_fname, dtype=np.int32,
+                                      mode=mode, offset=np.int32().itemsize, shape=size)
+            self.data_arr = np.memmap(self.data_fname, dtype=np.float32,
+                                      mode=mode, offset=np.float32().itemsize, shape=size)
+        else:
+            self.rows_arr.resize(size, refcheck=False)
+            self.cols_arr.resize(size, refcheck=False)
+            self.data_arr.resize(size, refcheck=False)
+
+        self.rows = self.rows_arr
+        self.cols = self.cols_arr
+        self.data = self.data_arr
+
+    cdef void set_entry(self, int pos, int row, int col, float datum):
+        """
+        """
+
+        self.rows[pos] = row
+        self.cols[pos] = col
+        self.data[pos] = datum
+
+    cdef void flush(self):
+        """
+        """
+
+        if self.memmap == 1:
+            self.rows_arr.flush()
+            self.cols_arr.flush()
+            self.data_arr.flush()
+
+
 cdef class Matrix:
     """
     A sparse co-occurrence matrix storing
@@ -29,71 +113,81 @@ cdef class Matrix:
     """
 
     cdef int max_map_size
+    cdef int map_size
+    cdef COOMatrix matrix
     cdef vector[unordered_map[int, float]] rows
 
-    cdef vector[vector[int]] row_indices
-    cdef vector[vector[float]] row_data
-
-    def __cinit__(self, int max_map_size):
+    def __cinit__(self, int max_map_size, row_fname, col_fname, data_fname):
 
         self.max_map_size = max_map_size
+        self.map_size = 0
         self.rows = vector[unordered_map[int, float]]()
 
-        self.row_indices = vector[vector[int]]()
-        self.row_data = vector[vector[float]]()
+        self.matrix = COOMatrix(row_fname, col_fname, data_fname)
 
-    cdef void compactify_row(self, int row):
+    cdef void compactify(self):
         """
-        Move a row from a map to more efficient
-        vector storage.
+        Move all entries from row maps to more efficient
+        array storage.
         """
 
-        cdef int i, col
-        cdef int row_length = self.row_indices[row].size()
-
+        cdef int i, row, col, new_entry_offset
         cdef pair[int, float] row_entry
         cdef unordered_map[int, float].iterator row_iterator
+        cdef COOMatrix coo = self.matrix
 
-        row_unordered_map = self.rows[row]
+        # print 'trying to compactify'
 
-        # Go through the elements already in vector storage
-        # and update them with the contents of a map, removing
-        # map elements as they are transferred.
-        for i in range(row_length):
-            col = self.row_indices[row][i]
-            if self.rows[row].find(col) != self.rows[row].end():
+        # Increment entries already in array storage.
+        for i in range(coo.size()):
 
-                self.row_data[row][i] += self.rows[row][col]
+            row = coo.rows[i]
+            col = coo.cols[i]
+
+            # If we have the entry in the map, move
+            # it to array storage and erase from the
+            # map.
+            if (self.rows[row].find(col)
+                != self.rows[row].end()):
+
+                coo.data[i] += self.rows[row][col]
                 self.rows[row].erase(col)
+                self.map_size -= 1
 
-        # Resize the vectors to accommodate new
-        # columns from the map.
-        row_length = self.row_indices[row].size()
-        self.row_indices[row].resize(row_length)
-        self.row_data[row].resize(row_length)
+        # print 'incremented existing entries'
 
-        # Add any new columns to the vector.
-        row_iterator = self.rows[row].begin()
-        while row_iterator != self.rows[row].end():
-            row_entry = deref(row_iterator)
-            self.row_indices[row].push_back(row_entry.first)
-            self.row_data[row].push_back(row_entry.second)
-            inc(row_iterator)
+        # All remaining entries in the map are not
+        # already in the arrays: we need to resize
+        # them to accommodate new entries.
+        new_entry_offset = coo.size()
+        coo.resize(new_entry_offset + self.map_size)
 
-        self.rows[row].clear()
+        for row in range(self.rows.size()):
+            row_iterator = self.rows[row].begin()
+            while row_iterator != self.rows[row].end():
+                row_entry = deref(row_iterator)
+                coo.set_entry(new_entry_offset,
+                              row, row_entry.first,
+                              row_entry.second)
+                new_entry_offset += 1
+                self.map_size -= 1
+                inc(row_iterator)
+
+            self.rows[row].clear()
+
+        coo.flush()
 
     cdef void add_row(self):
         """
-        Add a new row to the matrix.
+        Add a new row to the matrix map.
         """
 
         cdef unordered_map[int, float] row_map
 
         row_map = unordered_map[int, float]()
-
         self.rows.push_back(row_map)
-        self.row_indices.push_back(vector[int]())
-        self.row_data.push_back(vector[float]())
+
+        # print 'added row'
 
     cdef void increment(self, int row, int col, float value):
         """
@@ -101,14 +195,22 @@ cdef class Matrix:
         """
 
         cdef float current_value
+        cdef int preinsert_size
 
         while row >= self.rows.size():
-            self.add_row()        
+            self.add_row()
+
+        preinsert_size = self.rows[row].size()
 
         self.rows[row][col] += value
 
-        if self.rows[row].size() > self.max_map_size:
-            self.compactify_row(row)
+        if self.rows[row].size() > preinsert_size:
+            self.map_size += 1
+
+        if self.map_size > self.max_map_size:
+            self.compactify()
+
+        # print 'Incremented'
 
     cdef int size(self):
         """
@@ -120,7 +222,6 @@ cdef class Matrix:
 
         for i in range(self.rows.size()):
             size += self.rows[i].size()
-            size += self.row_indices[i].size()
 
         return size
 
@@ -129,39 +230,17 @@ cdef class Matrix:
         Convert to a shape by shape COO matrix.
         """
 
-        cdef int i, j
-        cdef int row
-        cdef int col
-        cdef int rows = self.rows.size()
-        cdef int no_collocations
-
-        # Transform all row maps to row arrays.
-        for i in range(rows):
-            self.compactify_row(i)
-
-        no_collocations = self.size()
-
-        # Create the constituent numpy arrays.
-        row_np = np.empty(no_collocations, dtype=np.int32)
-        col_np = np.empty(no_collocations, dtype=np.int32)
-        data_np = np.empty(no_collocations, dtype=np.float64)
-        cdef int[:,] row_view = row_np
-        cdef int[:,] col_view = col_np
-        cdef double[:,] data_view = data_np
-
-        j = 0
-
-        for row in range(rows):
-            for i in range(self.row_indices[row].size()):
-
-                row_view[j] = row
-                col_view[j] = self.row_indices[row][i]
-                data_view[j] = self.row_data[row][i]
-
-                j += 1
+        self.compactify()
 
         # Create and return the matrix.
-        return sp.coo_matrix((data_np, (row_np, col_np)),
+        ## mat = sp.coo_matrix((shape, shape), np.float64)
+        ## mat.data = self.matrix.data
+        ## mat.row = self.matrix.rows
+        ## mat.col = self.matrix.cols
+
+        ## return mat
+        return sp.coo_matrix((self.matrix.data,
+                             (self.matrix.rows, self.matrix.cols)),
                              shape=(shape,
                                     shape),
                              dtype=np.float64)
@@ -169,12 +248,10 @@ cdef class Matrix:
     def __dealloc__(self):
 
         self.rows.clear()
-        self.row_indices.clear()
-        self.row_data.clear()
 
 
 cdef inline int words_to_ids(list words, vector[int]& word_ids,
-                      dictionary, int supplied, int ignore_missing):
+                             dictionary, int supplied, int ignore_missing):
     """
     Convert a list of words into a vector of word ids, using either
     the supplied dictionary or by consructing a new one.
@@ -216,7 +293,8 @@ cdef inline int words_to_ids(list words, vector[int]& word_ids,
             
 def construct_cooccurrence_matrix(corpus, dictionary, int supplied,
                                   int window_size, int ignore_missing,
-                                  int max_map_size):
+                                  int max_map_size, row_fname, col_fname,
+                                  data_fname):
     """
     Construct the word-id dictionary and cooccurrence matrix for
     a given corpus, using a given window size.
@@ -224,8 +302,11 @@ def construct_cooccurrence_matrix(corpus, dictionary, int supplied,
     Returns the dictionary and a scipy.sparse COO cooccurrence matrix.
     """
 
+    # print 'trying to create the matrix'
     # Declare the cooccurrence map
-    cdef Matrix matrix = Matrix(max_map_size)
+    cdef Matrix matrix = Matrix(max_map_size, row_fname, col_fname, data_fname)
+
+    # print 'created matrix'
 
     # String processing variables.
     cdef list words

--- a/glove/corpus_cython.pyx
+++ b/glove/corpus_cython.pyx
@@ -23,6 +23,7 @@ cdef extern from "math.h":
 
 cdef class COOMatrix:
     """
+    A rudimentary COO matrix.
     """
 
     cdef public rows_arr

--- a/glove/glove.py
+++ b/glove/glove.py
@@ -81,7 +81,8 @@ class Glove(object):
         - scipy.sparse.coo_matrix matrix: coocurrence matrix
         - int epochs: number of training epochs
         - int no_threads: number of training threads
-        - bool shuffle: whether to shuffle the co-occurrence matrix
+        - bool shuffle: whether to shuffle the co-occurrence matrix. Note that
+                        the matrix will be shuffled in-place.
         - bool verbose: print progress messages if True
         """
 

--- a/glove/glove.py
+++ b/glove/glove.py
@@ -22,7 +22,8 @@ class Glove(object):
     """
 
     def __init__(self, no_components=30, learning_rate=0.05,
-                 alpha=0.75, max_count=100, max_loss=10.0):
+                 alpha=0.75, max_count=100, max_loss=10.0,
+                 random_seed=None):
         """
         Parameters:
         - int no_components: number of latent dimensions
@@ -34,6 +35,8 @@ class Glove(object):
                           Only try setting to a lower value if you
                           are experiencing problems with numerical
                           stability.
+        - int random_seed: the seed used for shuffling the co-occurrence matrix
+                           (if used) and initializing the word vectors.
         """
         
         self.no_components = no_components
@@ -41,6 +44,8 @@ class Glove(object):
         self.alpha = float(alpha)
         self.max_count = float(max_count)
         self.max_loss = max_loss
+
+        self.random_state = np.random.RandomState(random_seed)
 
         self.word_vectors = None
         self.word_biases = None
@@ -51,7 +56,24 @@ class Glove(object):
         self.dictionary = None
         self.inverse_dictionary = None
 
-    def fit(self, matrix, epochs=5, no_threads=2, verbose=False):
+    def _shuffle_coo_matrix(self, *arrays):
+        """
+        Consistently shuffle the constituent arrays of
+        a COO matrix in-place.
+        """
+
+        rng_state = self.random_state.get_state()
+
+        for arr in arrays:
+            self.random_state.set_state(rng_state)
+            self.random_state.shuffle(arr)
+
+            # If we are shuffling a memmapped array, flush the
+            # changes to disk.
+            if arr.base is not None and hasattr(arr.base, 'flush'):
+                arr.base.flush()
+
+    def fit(self, matrix, epochs=5, no_threads=2, shuffle=True, verbose=False):
         """
         Estimate the word embeddings.
 
@@ -59,6 +81,7 @@ class Glove(object):
         - scipy.sparse.coo_matrix matrix: coocurrence matrix
         - int epochs: number of training epochs
         - int no_threads: number of training threads
+        - bool shuffle: whether to shuffle the co-occurrence matrix
         - bool verbose: print progress messages if True
         """
 
@@ -71,16 +94,14 @@ class Glove(object):
         if not sp.isspmatrix_coo(matrix):
             raise Exception('Coocurrence matrix must be in the COO format')
 
-        self.word_vectors = ((np.random.rand(shape[0],
-                                             self.no_components) - 0.5)
-                                             / self.no_components)
+        self.word_vectors = ((self.random_state.rand(shape[0],
+                                                     self.no_components) - 0.5)
+                             / self.no_components)
         self.word_biases = np.zeros(shape[0], 
                                     dtype=np.float64)
 
         self.vectors_sum_gradients = np.ones_like(self.word_vectors)
         self.biases_sum_gradients = np.ones_like(self.word_biases)
-
-        shuffle_indices = np.arange(matrix.nnz, dtype=np.int32)
 
         if verbose:
             print('Performing %s training epochs '
@@ -91,8 +112,10 @@ class Glove(object):
             if verbose:
                 print('Epoch %s' % epoch)
 
-            # Shuffle the coocurrence matrix
-            np.random.shuffle(shuffle_indices)
+            if shuffle:
+                self._shuffle_coo_matrix(matrix.data,
+                                         matrix.row,
+                                         matrix.col)
 
             fit_vectors(self.word_vectors,
                         self.vectors_sum_gradients,
@@ -101,7 +124,6 @@ class Glove(object):
                         matrix.row,
                         matrix.col,
                         matrix.data,
-                        shuffle_indices,
                         self.learning_rate,
                         self.max_count,
                         self.alpha,
@@ -148,7 +170,7 @@ class Glove(object):
         sum_gradients = np.ones_like(paragraph_vector)
 
         # Shuffle the coocurrence matrix
-        np.random.shuffle(shuffle_indices)
+        self.random_state.shuffle(shuffle_indices)
         transform_paragraph(self.word_vectors,
                             self.word_biases,
                             paragraph_vector,

--- a/glove/glove.py
+++ b/glove/glove.py
@@ -140,7 +140,7 @@ class Glove(object):
                     raise
 
         word_ids = np.array(cooccurrence.keys(), dtype=np.int32)
-        values = np.array(cooccurrence.values(), dtype=np.float64)
+        values = np.array(cooccurrence.values(), dtype=np.float32)
         shuffle_indices = np.arange(len(word_ids), dtype=np.int32)
 
         # Initialize the vector to mean of constituent word vectors

--- a/glove/glove_cython.pyx
+++ b/glove/glove_cython.pyx
@@ -3,13 +3,10 @@
 
 import numpy as np
 import scipy.sparse as sp
-import collections
 from cython.parallel import parallel, prange
 
 
 cdef inline double double_min(double a, double b) nogil: return a if a <= b else b
-cdef inline int int_min(int a, int b) nogil: return a if a <= b else b
-cdef inline int int_max(int a, int b) nogil: return a if a > b else b
 
 
 cdef extern from "math.h" nogil:

--- a/glove/glove_cython.pyx
+++ b/glove/glove_cython.pyx
@@ -23,7 +23,7 @@ def fit_vectors(double[:, ::1] wordvec,
                 double[::1] wordbias_sum_gradients,
                 int[::1] row,
                 int[::1] col,
-                double[::1] counts,
+                float[::1] counts,
                 int[::1] shuffle_indices,
                 double initial_learning_rate,
                 double max_count,
@@ -46,7 +46,8 @@ def fit_vectors(double[:, ::1] wordvec,
     # Hold indices of current words and
     # the cooccurrence count.
     cdef int word_a, word_b
-    cdef double count, learning_rate, gradient
+    cdef float count
+    cdef double learning_rate, gradient
 
     # Loss and gradient variables.
     cdef double prediction, entry_weight, loss
@@ -113,7 +114,7 @@ def transform_paragraph(double[:, ::1] wordvec,
                         double[::1] paragraphvec,
                         double[::1] sum_gradients,
                         int[::1] row,
-                        double[::1] counts,
+                        float[::1] counts,
                         int[::1] shuffle_indices,
                         double initial_learning_rate,
                         double max_count,
@@ -138,7 +139,7 @@ def transform_paragraph(double[:, ::1] wordvec,
     # Hold indices of current words and
     # the cooccurrence count.
     cdef int word_b, word_a
-    cdef double count
+    cdef float count
 
     # Loss and gradient variables.
     cdef double prediction

--- a/glove/glove_cython.pyx
+++ b/glove/glove_cython.pyx
@@ -24,7 +24,6 @@ def fit_vectors(double[:, ::1] wordvec,
                 int[::1] row,
                 int[::1] col,
                 float[::1] counts,
-                int[::1] shuffle_indices,
                 double initial_learning_rate,
                 double max_count,
                 double alpha,
@@ -53,17 +52,17 @@ def fit_vectors(double[:, ::1] wordvec,
     cdef double prediction, entry_weight, loss
 
     # Iteration variables
-    cdef int i, j, shuffle_index
+    cdef int i, j
 
     # We iterate over random indices to simulate
     # shuffling the cooccurrence matrix.
     with nogil:
         for j in prange(no_cooccurrences, num_threads=no_threads,
                         schedule='dynamic'):
-            shuffle_index = shuffle_indices[j]
-            word_a = row[shuffle_index]
-            word_b = col[shuffle_index]
-            count = counts[shuffle_index]
+
+            word_a = row[j]
+            word_b = col[j]
+            count = counts[j]
 
             # Get prediction
             prediction = 0.0

--- a/glove/tests/test_corpus.py
+++ b/glove/tests/test_corpus.py
@@ -8,6 +8,7 @@ from glove import Corpus
 
 
 MEMMAP_PREFIX = 'test_memmap'
+SAVE_FNAME = 'test_save_corpus'
 
 
 def test_corpus_construction():
@@ -15,11 +16,9 @@ def test_corpus_construction():
     corpus_words = ['a', 'naïve', 'fox']
     corpus = [corpus_words]
 
-    model = Corpus()
-
     for memmap_prefix in (None, MEMMAP_PREFIX):
-        model.fit(corpus, max_map_size=0, window=10,
-                  memmap_prefix=MEMMAP_PREFIX)
+        model = Corpus(memmap_prefix=MEMMAP_PREFIX)
+        model.fit(corpus, max_map_size=0, window=10)
 
         for word in corpus_words:
             assert word in model.dictionary
@@ -35,6 +34,26 @@ def test_corpus_construction():
                 == expected)
 
 
+def test_save_load():
+
+    corpus_words = ['a', 'naïve', 'fox']
+    corpus = [corpus_words]
+
+    expected = [[0.0, 1.0, 0.5],
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0]]
+
+    for memmap_prefix in (None, MEMMAP_PREFIX):
+        model = Corpus(memmap_prefix=MEMMAP_PREFIX)
+        model.fit(corpus, max_map_size=0, window=10)
+
+        model.save(SAVE_FNAME)
+        model = Corpus.load(SAVE_FNAME)
+
+        assert (model.matrix.todense().tolist()
+                == expected)
+
+
 def test_supplied_dictionary():
 
     dictionary = {'a': 2,
@@ -43,11 +62,10 @@ def test_supplied_dictionary():
 
     corpus = [['a', 'naïve', 'fox']]
 
-    model = Corpus(dictionary=dictionary)
-
     for memmap_prefix in (None, MEMMAP_PREFIX):
-        model.fit(corpus, max_map_size=0, window=10,
-                  memmap_prefix=MEMMAP_PREFIX)
+        model = Corpus(dictionary=dictionary,
+                       memmap_prefix=MEMMAP_PREFIX)
+        model.fit(corpus, max_map_size=0, window=10)
 
         assert model.dictionary == dictionary
 
@@ -88,11 +106,11 @@ def test_supplied_dict_missing_ignored():
 
     corpus = [['a', 'naïve', 'fox']]
 
-    model = Corpus(dictionary=dictionary)
-
     for memmap_prefix in (None, MEMMAP_PREFIX):
+        model = Corpus(dictionary=dictionary,
+                       memmap_prefix=MEMMAP_PREFIX)
         model.fit(corpus, max_map_size=0, window=10,
-                  memmap_prefix=MEMMAP_PREFIX, ignore_missing=True)
+                  ignore_missing=True)
 
         assert model.dictionary == dictionary
 

--- a/glove/tests/test_corpus.py
+++ b/glove/tests/test_corpus.py
@@ -40,6 +40,7 @@ def test_corpus_construction():
                     [0.0, 0.0, 1.0],
                     [0.0, 0.0, 0.0]]
 
+        assert model.matrix.data.min() > 0
         assert (model.matrix.todense().tolist()
                 == expected)
 
@@ -62,6 +63,7 @@ def test_save_load():
         model.save(SAVE_FNAME)
         model = Corpus.load(SAVE_FNAME)
 
+        assert model.matrix.data.min() > 0
         assert (model.matrix.todense().tolist()
                 == expected)
 

--- a/glove/tests/test_corpus.py
+++ b/glove/tests/test_corpus.py
@@ -10,6 +10,16 @@ from glove import Corpus
 MEMMAP_PREFIX = 'test_memmap'
 SAVE_FNAME = 'test_save_corpus'
 
+def _check_memmap(matrix):
+
+    assert not matrix.row.flags['OWNDATA']
+    assert not matrix.col.flags['OWNDATA']
+    assert not matrix.data.flags['OWNDATA']
+    
+    assert isinstance(matrix.row.base, np.memmap)
+    assert isinstance(matrix.col.base, np.memmap)
+    assert isinstance(matrix.data.base, np.memmap)
+
 
 def test_corpus_construction():
 
@@ -33,6 +43,8 @@ def test_corpus_construction():
         assert (model.matrix.todense().tolist()
                 == expected)
 
+        if memmap_prefix:
+            _check_memmap(model.matrix)
 
 def test_save_load():
 
@@ -52,6 +64,9 @@ def test_save_load():
 
         assert (model.matrix.todense().tolist()
                 == expected)
+
+        if memmap_prefix:
+            _check_memmap(model.matrix)
 
 
 def test_supplied_dictionary():

--- a/glove/tests/test_glove.py
+++ b/glove/tests/test_glove.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import numpy as np
+import scipy.sparse as sp
+
 from glove import Glove
 
 
@@ -18,3 +21,37 @@ def test_stanford_loading():
     except NameError:
         # Pyton 3
         assert '…' in model.dictionary
+
+
+def test_shuffling():
+
+    shape = 10
+
+    row = np.random.randint(shape, size=shape).astype(np.int32)
+    col = np.random.randint(shape, size=shape).astype(np.int32)
+    data = np.random.rand(shape)
+
+    row_copy = row.copy()
+    col_copy = col.copy()
+    data_copy = data.copy()
+
+    mat = sp.coo_matrix((data, (row, col)),
+                        shape=(shape, shape))
+    test_mat = sp.coo_matrix((data_copy, (row_copy, col_copy)),
+                             shape=(shape, shape))
+
+    # The same before...
+    assert np.all(mat.todense() == test_mat.todense())
+    
+    model = Glove(random_seed=10)
+    model._shuffle_coo_matrix(row, col, data)
+
+    # ...and after shuffling
+    assert np.all(mat.todense() == test_mat.todense())
+    assert not np.all(row == row_copy)
+    assert not np.all(col == col_copy)
+    assert not np.all(data == data_copy)
+
+
+
+    


### PR DESCRIPTION
This PR allows out-of-core computation of both the co-occurrence matrix and word vectors by using memory-mapped numpy arrays.

This should result in memory usage constant in the size of the training corpus, at the cost of a performance penalty related to the amount of memory available and the speed of persistent storage used.

@piskvorky