### PR TITLE
Call set_gcc function by default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools.command.test import test as TestCommand
 
 
 def define_extensions(cythonize=False):
-
+    set_gcc()
     compile_args = ['-fopenmp',
                     '-ffast-math']
 


### PR DESCRIPTION
Do you call the set_gcc function by default for OSX user?

Because set_gcc is not called by default, some researchers who
are not familiar with python can not install glove-python.